### PR TITLE
Update Install-MicrosoftVisualC++x86x64.wsf

### DIFF
--- a/Scripts/Install-MicrosoftVisualC++x86x64.wsf
+++ b/Scripts/Install-MicrosoftVisualC++x86x64.wsf
@@ -12,6 +12,7 @@
 '// Version: 2.3 - April 18, 2017 - Henrik Bacher
 '// Version: 2.4 - September 6, 2017 - Christoph Voigt
 '// Version: 2.5 - October 4, 2018 - Johan Arwidmark
+'// Version: 2.6 - November 27, 2019 - Ramón Isasi
 '// 
 '// Twitter: @jarwidmark
 '// Blog   : http://deploymentresearch.com
@@ -61,9 +62,13 @@ Function ZTIProcess()
 	'// (Visual C++ 2017 is a binary-compatible in-place upgrade of Visual C++ 2015)
 	'Dim sSetupFile2015x86
 	'Dim sSetupFile2015x64
-	'//
-	Dim sSetupFile2017x86
-	Dim sSetupFile2017x64
+	'// Removed Visual C++ 2017 since it's replaced with 2019
+	'// (Visual C++ 2019 is a binary-compatible in-place upgrade of Visual C++ 2015 and 2017)
+	'Dim sSetupFile2017x86
+	'Dim sSetupFile2017x64
+
+	Dim sSetupFile2019x86
+	Dim sSetupFile2019x64
 	
 
 	Dim sArguments
@@ -91,8 +96,10 @@ Function ZTIProcess()
 	'// Removed Visual C++ 2015 since it's replaced with 2017 
 	'sSetupFile2015x86 = oUtility.ScriptDir & "\Source\VS2015\mu_visual_cpp_2015_redistributable_update_3_x86_9052536.exe"
 	'sSetupFile2015x64 = oUtility.ScriptDir & "\Source\VS2015\mu_visual_cpp_2015_redistributable_update_3_x64_9052538.exe"
-	sSetupFile2017x86 = oUtility.ScriptDir & "\Source\VS2017\mu_visual_cpp_redistributable_for_visual_studio_2017_version_15.3_x86_11100229.exe"
-	sSetupFile2017x64 = oUtility.ScriptDir & "\Source\VS2017\mu_visual_cpp_redistributable_for_visual_studio_2017_version_15.3_x64_11100230.exe"
+	'sSetupFile2017x86 = oUtility.ScriptDir & "\Source\VS2017\mu_visual_cpp_redistributable_for_visual_studio_2017_version_15.3_x86_11100229.exe"
+	'sSetupFile2017x64 = oUtility.ScriptDir & "\Source\VS2017\mu_visual_cpp_redistributable_for_visual_studio_2017_version_15.3_x64_11100230.exe"
+	sSetupFile2019x86 = oUtility.ScriptDir & "\Source\VS2019\vcredist_x86.exe"
+	sSetupFile2019x64 = oUtility.ScriptDir & "\Source\VS2019\vcredist_x64.exe"
 	
 	sArguments = "/Q"
 
@@ -139,8 +146,15 @@ Function ZTIProcess()
 	'	Exit Function
 	'End if
 
-	If not oFSO.FileExists(sSetupFile2017x86) then
-		oLogging.CreateEntry oUtility.ScriptName & ": " & sSetupFile2017x86 & " was not found, unable to install", LogTypeError
+	'// Removed Visual C++ 2017 since it's replaced with 2019 
+	'If not oFSO.FileExists(sSetupFile2017x86) then
+	'	oLogging.CreateEntry oUtility.ScriptName & ": " & sSetupFile2017x86 & " was not found, unable to install", LogTypeError
+	'	ZTIProcess = Failure
+	'	Exit Function
+	'End if
+	
+	If not oFSO.FileExists(sSetupFile2019x86) then
+		oLogging.CreateEntry oUtility.ScriptName & ": " & sSetupFile2019x86 & " was not found, unable to install", LogTypeError
 		ZTIProcess = Failure
 		Exit Function
 	End if
@@ -232,10 +246,21 @@ Function ZTIProcess()
 	
 	'oLogging.CreateEntry oUtility.ScriptName & ": Return code from command = " & iRetVal, LogTypeInfo
 	'oLogging.CreateEntry oUtility.ScriptName & ": Finished installation", LogTypeInfo
-	
+
+	'// Removed Visual C++ 2017 since it's replaced with 2019 
 	'// Installing Visual C++ 2017 x86
-	oLogging.CreateEntry oUtility.ScriptName & ": About to install " & sSetupFile2017x86, LogTypeInfo
-	iRetVal = oUtility.RunWithHeartbeat("""" & sSetupFile2017x86 & """ " & sArguments)
+	'oLogging.CreateEntry oUtility.ScriptName & ": About to install " & sSetupFile2017x86, LogTypeInfo
+	'iRetVal = oUtility.RunWithHeartbeat("""" & sSetupFile2017x86 & """ " & sArguments)
+	'
+	'if (iRetVal = 0) or (iRetVal = 3010) then
+	'	ZTIProcess = Success 
+	'Else 
+	'	ZTIProcess = Failure
+	'End If
+
+	'// Installing Visual C++ 2019 x86
+	oLogging.CreateEntry oUtility.ScriptName & ": About to install " & sSetupFile2019x86, LogTypeInfo
+	iRetVal = oUtility.RunWithHeartbeat("""" & sSetupFile2019x86 & """ " & sArguments)
 	
 	if (iRetVal = 0) or (iRetVal = 3010) then
 		ZTIProcess = Success 
@@ -293,12 +318,19 @@ Function ZTIProcess()
 		'	Exit Function
 		'End if
 
-		If not oFSO.FileExists(sSetupFile2017x64) then
-			oLogging.CreateEntry oUtility.ScriptName & ": " & sSetupFile2017x64 & " was not found, unable to install", LogTypeError
+		'// Removed Visual C++ 2017 since it's replaced with 2019 
+		'If not oFSO.FileExists(sSetupFile2017x64) then
+		'	oLogging.CreateEntry oUtility.ScriptName & ": " & sSetupFile2017x64 & " was not found, unable to install", LogTypeError
+		'	ZTIProcess = Failure
+		'	Exit Function
+		'End if
+
+		If not oFSO.FileExists(sSetupFile2019x64) then
+			oLogging.CreateEntry oUtility.ScriptName & ": " & sSetupFile2019x64 & " was not found, unable to install", LogTypeError
 			ZTIProcess = Failure
 			Exit Function
 		End if
-	
+		
 		'Installing x64 files
 
 		'// Removed Visual C++ 2005 since it's no longer supported (and don't get security updates)
@@ -385,15 +417,27 @@ Function ZTIProcess()
 		'oLogging.CreateEntry oUtility.ScriptName & ": Return code from command = " & iRetVal, LogTypeInfo
 		'oLogging.CreateEntry oUtility.ScriptName & ": Finished installation", LogTypeInfo
 
+		'// Removed Visual C++ 2017 since it's replaced with 2019
 		'// Installing Visual C++ 20017x64
-		oLogging.CreateEntry oUtility.ScriptName & ": About to install " & sSetupFile2017x64, LogTypeInfo
-		iRetVal = oUtility.RunWithHeartbeat("""" & sSetupFile2017x64 & """ " & sArguments)
+		'oLogging.CreateEntry oUtility.ScriptName & ": About to install " & sSetupFile2017x64, LogTypeInfo
+		'iRetVal = oUtility.RunWithHeartbeat("""" & sSetupFile2017x64 & """ " & sArguments)
+		'
+		'if (iRetVal = 0) or (iRetVal = 3010) then
+		'	ZTIProcess = Success 
+		'Else 
+		'	ZTIProcess = Failure
+		'End If
+
+		'// Installing Visual C++ 20019x64
+		oLogging.CreateEntry oUtility.ScriptName & ": About to install " & sSetupFile2019x64, LogTypeInfo
+		iRetVal = oUtility.RunWithHeartbeat("""" & sSetupFile2019x64 & """ " & sArguments)
 		
 		if (iRetVal = 0) or (iRetVal = 3010) then
 			ZTIProcess = Success 
 		Else 
 			ZTIProcess = Failure
 		End If
+		
 		
 		oLogging.CreateEntry oUtility.ScriptName & ": Return code from command = " & iRetVal, LogTypeInfo
 		oLogging.CreateEntry oUtility.ScriptName & ": Finished installation", LogTypeInfo

--- a/Scripts/Install-MicrosoftVisualC++x86x64.wsf
+++ b/Scripts/Install-MicrosoftVisualC++x86x64.wsf
@@ -219,6 +219,9 @@ Function ZTIProcess()
 	oLogging.CreateEntry oUtility.ScriptName & ": Return code from command = " & iRetVal, LogTypeInfo
 	oLogging.CreateEntry oUtility.ScriptName & ": Finished installation", LogTypeInfo
 
+	'// Modified installation switch due to changes introduced from version 2013 and newer
+	sArguments = "/quiet /norestart"
+	
 	'// Installing Visual C++ 2013 x86
 	oLogging.CreateEntry oUtility.ScriptName & ": About to install " & sSetupFile2013x86, LogTypeInfo
 	iRetVal = oUtility.RunWithHeartbeat("""" & sSetupFile2013x86 & """ " & sArguments)
@@ -333,6 +336,9 @@ Function ZTIProcess()
 		
 		'Installing x64 files
 
+		'// Reverting back to old silent installation switch
+		sArguments = "/Q"
+	
 		'// Removed Visual C++ 2005 since it's no longer supported (and don't get security updates)
 		'// Installing Visual C++ 2005 x64
 		'oLogging.CreateEntry oUtility.ScriptName & ": About to install " & sSetupFile2005x64, LogTypeInfo
@@ -390,6 +396,9 @@ Function ZTIProcess()
 		oLogging.CreateEntry oUtility.ScriptName & ": Finished installation", LogTypeInfo
 
 
+		'// Modified installation switch due to changes introduced from version 2013 and newer
+		sArguments = "/quiet /norestart"
+	
 		'// Installing Visual C++ 2013 x64
 		oLogging.CreateEntry oUtility.ScriptName & ": About to install " & sSetupFile2013x64, LogTypeInfo
 		iRetVal = oUtility.RunWithHeartbeat("""" & sSetupFile2013x64 & """ " & sArguments)

--- a/Scripts/Install-MicrosoftVisualC++x86x64.wsf
+++ b/Scripts/Install-MicrosoftVisualC++x86x64.wsf
@@ -12,6 +12,7 @@
 '// Version: 2.3 - April 18, 2017 - Henrik Bacher
 '// Version: 2.4 - September 6, 2017 - Christoph Voigt
 '// Version: 2.5 - October 4, 2018 - Johan Arwidmark
+'// Version: 2.5.1 - August 12, 2019 - Baard Hermansen
 '// Version: 2.6 - November 27, 2019 - Ramón Isasi
 '// 
 '// Twitter: @jarwidmark


### PR DESCRIPTION
Replaced Visual C++ 2017 with 2019 as it is binary compatible with Visual C++ 2015 and Visual C++ 2017
Include fix #19 to silently install 2013 and newer '// Version: 2.5.1 - August 12, 2019 - Baard Hermansen

Also proposed an update to download.xml file to include the last version
https://github.com/DeploymentBunny/Files/compare/master...ramonisasi:patch-1#diff-3c91c52aa0ed0426c2eadf4b10ed334a